### PR TITLE
fix build on gcc-10 (-fno-common)

### DIFF
--- a/gui/gui.c
+++ b/gui/gui.c
@@ -56,6 +56,7 @@
 #include "session.h"
 #include "waveform.h"
 
+GtkRecentManager *recent_manager;
 
 /* windows */
 static GtkWidget* window = 0;

--- a/gui/gui.h
+++ b/gui/gui.h
@@ -107,6 +107,6 @@ GtkWidget*
 
 void gui_set_session_mode(void);
 
-GtkRecentManager *recent_manager;
+extern GtkRecentManager *recent_manager;
  
 #endif /* __GUI_H__ */


### PR DESCRIPTION
gcc-10 changed the default from -fcommon to fno-common:
  https://gcc.gnu.org/PR85678

As a result build fails as:

    ld: CMakeFiles/petri-foo.dir/voicetab.c.o:(.bss+0x0): multiple definition of
      `recent_manager'; CMakeFiles/petri-foo.dir/audio-settings.c.o:(.bss+0x0): first defined here